### PR TITLE
deps: add isaacsim-extscache-kit to dependencies

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -55,6 +55,7 @@ environments:
       - pypi: https://pypi.nvidia.com/isaacsim-app/isaacsim_app-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=51224da7d74179055456f7a6448e940f0a186249eaaa2b77e96f368a95dc06cb
       - pypi: https://pypi.nvidia.com/isaacsim-benchmark/isaacsim_benchmark-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=2de38ae6a6fc0637fa12bc29f668f3f04dad6f7c639a370b0300a48c174c098d
       - pypi: https://pypi.nvidia.com/isaacsim-core/isaacsim_core-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=ca73ce9d2ff9d693cd8fcf44e67569a2e0cbc44009e58c39506bc851d23ad2a6
+      - pypi: https://pypi.nvidia.com/isaacsim-extscache-kit/isaacsim_extscache_kit-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=2ff59ec1c8fedc7505aff54d6e1a2c15739874307a97effd33680ef27f973c7a
       - pypi: https://pypi.nvidia.com/isaacsim-extscache-kit-sdk/isaacsim_extscache_kit_sdk-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=edceebb3325b3c4bdaf1e5b19bb1251c895daaf59348990726bfee3ca0ce7e60
       - pypi: https://pypi.nvidia.com/isaacsim-extscache-physics/isaacsim_extscache_physics-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=61f13f6d1b0aeef9ab522a7c3c7ffd414ac390840ae855a80fa49d558990481b
       - pypi: https://pypi.nvidia.com/isaacsim-gui/isaacsim_gui-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=0fa88e3613499670a45dbda745ebc486426b2bafa4c868ce23e44e7396095f66
@@ -571,7 +572,7 @@ packages:
   name: isaac-lab-env
   version: 0.2.0
   path: .
-  sha256: bd41ff3732d075835d38ce6b581bee20782b89d5d4a987386f61d2a3d6faf973
+  sha256: ed6b09033094f57f11dc8d5dec7d41eace440d21d7965e2d42f4a67d78385711
   requires_dist:
   - black>=23,<=24.10.0 ; extra == 'test'
   - pylint>=3.2.5,<=3.3.1 ; extra == 'test'
@@ -613,6 +614,12 @@ packages:
   - psutil
   - boto3
   - pyyaml
+  requires_python: ==3.10.*
+- kind: pypi
+  name: isaacsim-extscache-kit
+  version: 4.2.0.2
+  url: https://pypi.nvidia.com/isaacsim-extscache-kit/isaacsim_extscache_kit-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=2ff59ec1c8fedc7505aff54d6e1a2c15739874307a97effd33680ef27f973c7a
+  sha256: 2ff59ec1c8fedc7505aff54d6e1a2c15739874307a97effd33680ef27f973c7a
   requires_python: ==3.10.*
 - kind: pypi
   name: isaacsim-extscache-kit-sdk

--- a/pixi.lock
+++ b/pixi.lock
@@ -5,8 +5,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    - https://download.pytorch.org/whl/cu121
-    - https://pypi.nvidia.com/
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -24,7 +22,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.2-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.0-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.2-pyh8b19718_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.15-h4a871b0_2_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
@@ -36,66 +34,76 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/41/30/624365383fa4a40329c0f0bbbc151abc4a64e30dfc110fc8f6e2afcd02bb/astroid-3.3.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/21/5b6702a7f963e95456c0de2d495f67bf5fd62840ac655dc451586d23d39a/attrs-24.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6e/c5/9023b7673904a5188f9be81f5e129fff69f51f5515655fbd1d5a4e80a47b/black-24.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/5a/b4/2aa8168bb1d80c238538ff523d8902a48b0946aafd3cbd6c72754209ae8a/boto3-1.35.57-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f6/29/6c3a0f688e7c19e2a3734ab0f50cbf85138c1d7a432db8ef4f51f7bae892/botocore-1.35.57-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c6/d1/428fe22e6b0b090161a01977edab1836662b6442614f1d9ec77df99d4e6f/boto3-1.35.58-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7c/05/a09e7f96dd7875238a69963da091c8b239329cb3306fbb5af5ad6f6dfb2a/botocore-1.35.58-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/41/e1d85ca3cab0b674e277c8c4f678cf66a91cd2cecf93df94353a606fe0db/cloudpickle-3.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/99/e6/d11966962b1aa515f5586d3907ad019f4b812c04e4546cc19ebf62b5178e/contourpy-1.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/a9/57/86c500d63b3e26e5b73a28b8291a67c5608d4aa87ebd17bd15bb33c178bc/contourpy-1.3.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/8d/95/565c310fffa16ede1a042e9ea1ca3962af0d8eb5543bc72df6b91dc0c3d5/coverage-7.6.4-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/46/d1/e73b6ad76f0b1fb7f23c35c6d95dbc506a9c8804f43dda8cb5b0fa6331fd/dill-0.3.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/02/cc/b7e31358aac6ed1ef2bb790a9746ac2c69bcb3c8588b41616914eb106eaf/exceptiongroup-1.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/05/2c/ffc08c54c05cdce6fbed2aeebc46348dbe180c6d2c541c7af7ba0aa5f5f8/Farama_Notifications-0.0.4-py3-none-any.whl
-      - pypi: https://download.pytorch.org/whl/filelock-3.13.1-py3-none-any.whl#sha256=57dbda9b35157b05fb3e58ee91448612eb674172fab98ee235ccb0b5bee19a1c
+      - pypi: https://files.pythonhosted.org/packages/b9/f8/feced7779d755758a52d1f6635d990b8d98dc0a29fa568bbe0625f18fdf3/filelock-3.16.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e5/12/9a45294a7c4520cc32936edd15df1d5c24af701d2f5f51070a9a43d7664b/fonttools-4.54.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://download.pytorch.org/whl/fsspec-2024.2.0-py3-none-any.whl#sha256=817f969556fa5916bc682e02ca2045f96ff7f586d45110fcb76022063ad2c7d8
+      - pypi: https://files.pythonhosted.org/packages/c6/b2/454d6e7f0158951d8a78c2e1eb4f69ae81beb8dca5fee9809c6c99e9d0d0/fsspec-2024.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/de/85/f5039ce2df5f0789ff1240f08a59f3e8c92e4c5f99543b7aad7388532f7c/gymnasium-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7b/a2/97052c42f46fca976cf2d5d37ecf547062f2cb66f54a4f95442cf6610697/hypothesis-6.116.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl
-      - pypi: https://pypi.nvidia.com/isaacsim-app/isaacsim_app-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=51224da7d74179055456f7a6448e940f0a186249eaaa2b77e96f368a95dc06cb
-      - pypi: https://pypi.nvidia.com/isaacsim-benchmark/isaacsim_benchmark-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=2de38ae6a6fc0637fa12bc29f668f3f04dad6f7c639a370b0300a48c174c098d
-      - pypi: https://pypi.nvidia.com/isaacsim-core/isaacsim_core-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=ca73ce9d2ff9d693cd8fcf44e67569a2e0cbc44009e58c39506bc851d23ad2a6
-      - pypi: https://pypi.nvidia.com/isaacsim-extscache-kit/isaacsim_extscache_kit-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=2ff59ec1c8fedc7505aff54d6e1a2c15739874307a97effd33680ef27f973c7a
-      - pypi: https://pypi.nvidia.com/isaacsim-extscache-kit-sdk/isaacsim_extscache_kit_sdk-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=edceebb3325b3c4bdaf1e5b19bb1251c895daaf59348990726bfee3ca0ce7e60
-      - pypi: https://pypi.nvidia.com/isaacsim-extscache-physics/isaacsim_extscache_physics-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=61f13f6d1b0aeef9ab522a7c3c7ffd414ac390840ae855a80fa49d558990481b
-      - pypi: https://pypi.nvidia.com/isaacsim-gui/isaacsim_gui-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=0fa88e3613499670a45dbda745ebc486426b2bafa4c868ce23e44e7396095f66
-      - pypi: https://pypi.nvidia.com/isaacsim-kernel/isaacsim_kernel-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=8c44f6e4a32b160682f148e098fe8fe9aec4406d2c203e6f0b0c3b48bd46313e
-      - pypi: https://pypi.nvidia.com/isaacsim-replicator/isaacsim_replicator-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=49e5cad782ee40db1735325278640dc9627d64d71d7a7eded053c0969dc48023
-      - pypi: https://pypi.nvidia.com/isaacsim-rl/isaacsim_rl-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=8297cde072f44087192f8db909bab2d4777dd6e9abc130d30796a9f812439401
-      - pypi: https://pypi.nvidia.com/isaacsim-robot/isaacsim_robot-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=b17a028d88e364d1b8810c6fa855b4e7fc35b804554adad459ea84cb2696ed29
-      - pypi: https://pypi.nvidia.com/isaacsim-robot-motion/isaacsim_robot_motion-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=e72b6b5126f9f04cf3b401ec33b1712963b4afc2d8081822cf405288e98c19a7
-      - pypi: https://pypi.nvidia.com/isaacsim-sensor/isaacsim_sensor-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=521d4bed279aa6b79d5c82d87d6702f605d9c058bcda876c1e8dffa1ed1468e7
-      - pypi: https://pypi.nvidia.com/isaacsim-storage/isaacsim_storage-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=06c5847bfe373aee0073bd29b33a352e7c7bdfa9083de1967e6a6fac75ef7eea
-      - pypi: https://pypi.nvidia.com/isaacsim-utils/isaacsim_utils-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=bf787163d85f182d08b8bd5dd61e21909c52c979cca44cb4ee06777ecdb443df
+      - pypi: https://files.pythonhosted.org/packages/3a/ab/5049162ff8632aa960f9d0ff86c752748f89258c3cde777922a3e73aac92/isaacsim-4.2.0.2.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/86/af/4f09ee828ef69ae5af56d95e2e139ac086d7e34c6d1468d615fcea3cb5f7/isaacsim_app-4.2.0.2.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/74/4c/5c12c2a767f83031b9acbe8894beb6d13a436e7613c6ad78e98cb1900afd/isaacsim_asset-4.2.0.2.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/86/f3/79eb20eef8e5cfd6741281c5188d7a621db2ce8bbcf18ac8d215abf1f6b7/isaacsim_benchmark-4.2.0.2.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/1e/a2/3cd3c4bba8919d37a53d05dfb72849061ebd05bbc51e18b64f74c1c15556/isaacsim_code_editor-4.2.0.2.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/97/10/d803f41166f0d95ded6d74e696ba144a01063cee1058afd75cf22c87436e/isaacsim_core-4.2.0.2.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/30/29/304ba9973d154fbb1eed8303b497f3f768d1f1ddde5a3bad63173c8c8e39/isaacsim_cortex-4.2.0.2.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/a6/3c/4f44601b95dbda015ba02b49ba19b4abe7c04259d978809e40fb6d3fb1e1/isaacsim_example-4.2.0.2.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/e1/51/932ca6b7ae104f2be2fe3ba3372488975625d038c739b38a16bbd45c3f04/isaacsim_extscache_kit-4.2.0.2.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/d5/4d/43b95048e4f7fe5ffe671903e12acbc890996ec48fc81d40faa4d5faead0/isaacsim_extscache_kit_sdk-4.2.0.2.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/26/39/f1e9d9b87222969ba456d485e39644fdfb57e99a77f075e82acea0b67b1f/isaacsim_extscache_physics-4.2.0.2.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/a7/26/3c6f3c1c3020048d0b952b4e8aee89c572af3c38211d5ae9e8d2f44fb9c6/isaacsim_gui-4.2.0.2.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/e4/ec/e1c4278e4abe0208b5f391761be8301c27f0ebab555155485fc0c7bdd54e/isaacsim_kernel-4.2.0.2.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/e4/62/d717e8d687efcd26e20730ad2dd7229b907d1e9d86f92a63aad4bf8ad9fe/isaacsim_replicator-4.2.0.2.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/ad/34/f4d76df53c9210543290bc302b5a11220c556639c0189bc02a323459c091/isaacsim_rl-4.2.0.2.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/5f/44/72dd6184e73ced8aafea52bf8cb33b30e5b596e3375b0446e98de27acab3/isaacsim_robot-4.2.0.2.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/74/8e/2d3b86995f000dc7ce9166b1848d4469866524ad129f192384685dc4847b/isaacsim_robot_motion-4.2.0.2.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/88/b2/f6faa50ddad1285549483b4e1e7ae52c3a3c455a3073eb394878ceb34a6e/isaacsim_robot_setup-4.2.0.2.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/43/52/73d5c6a7eaf3cc789bff60bed4eec14b3dbb070066a8d20c07f946b67170/isaacsim_ros1-4.2.0.2.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/64/69/3e158a209402fac1b10cb92fac62e1ef9e6ec3f1a41a72016e357e525dff/isaacsim_ros2-4.2.0.2.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/d2/dc/4640155628e73a99053e0cc481367c6f9e2f031f0b5d1ee41a0d96bd43a5/isaacsim_sensor-4.2.0.2.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/a5/3d/c21377ed8b1bf1a6f2c3ef146652f48134308e9807f6a573711acaea489e/isaacsim_storage-4.2.0.2.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/32/2c/4fd0f5d8e7ef8f57417a41bea4653d8d1439a0c30abf25b3b0d3c009421e/isaacsim_template-4.2.0.2.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/45/43/bc69acaf8ea438e1f2424bf7f9226c9a0caefa658f9e05bd992a96b1b42b/isaacsim_test-4.2.0.2.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/a1/0d/a9247259dc72262c7d5fdca71aa774989721cc9a58b5ea418ac179e1f29e/isaacsim_utils-4.2.0.2.tar.gz
       - pypi: https://files.pythonhosted.org/packages/d1/b3/8def84f539e7d2289a02f0524b944b15d7c75dab7628bedf1c4f0992029c/isort-5.13.2-py3-none-any.whl
-      - pypi: https://download.pytorch.org/whl/Jinja2-3.1.3-py3-none-any.whl#sha256=7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa
+      - pypi: https://files.pythonhosted.org/packages/31/80/3a54838c3fb461f6fec263ebf3a3a41771bd05190238de3486aae8540c36/jinja2-3.1.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/55/91/0a57ce324caf2ff5403edab71c508dd8f648094b18cfbb4c8cc0fde4a6ac/kiwisolver-1.4.7-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl
-      - pypi: https://download.pytorch.org/whl/MarkupSafe-2.1.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl#sha256=2174c595a0d73a3080ca3257b40096db99799265e1c27cc5a610743acd86d62f
+      - pypi: https://files.pythonhosted.org/packages/22/35/137da042dfb4720b638d2937c38a9c2df83fe32d20e8c8f3185dbfef05f7/MarkupSafe-3.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/8d/9d/d06860390f9d154fa884f1740a5456378fb153ff57443c91a4a32bab7092/matplotlib-3.9.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl
-      - pypi: https://download.pytorch.org/whl/mpmath-1.3.0-py3-none-any.whl#sha256=a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c
-      - pypi: https://download.pytorch.org/whl/mypy_extensions-1.0.0-py3-none-any.whl#sha256=4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d
-      - pypi: https://download.pytorch.org/whl/networkx-3.2.1-py3-none-any.whl#sha256=f18c69adc97877c42332c170849c96cefa91881c99a7cb3e95b7c659ebdc1ec2
-      - pypi: https://download.pytorch.org/whl/numpy-1.26.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl#sha256=bdd2b45bf079d9ad90377048e2747a0c82351989a2165821f0c96831b4a2a54b
-      - pypi: https://download.pytorch.org/whl/cu121/nvidia_cublas_cu12-12.1.3.1-py3-none-manylinux1_x86_64.whl#sha256=ee53ccca76a6fc08fb9701aa95b6ceb242cdaab118c3bb152af4e579af792728
-      - pypi: https://download.pytorch.org/whl/cu121/nvidia_cuda_cupti_cu12-12.1.105-py3-none-manylinux1_x86_64.whl#sha256=e54fde3983165c624cb79254ae9818a456eb6e87a7fd4d56a2352c24ee542d7e
-      - pypi: https://download.pytorch.org/whl/cu121/nvidia_cuda_nvrtc_cu12-12.1.105-py3-none-manylinux1_x86_64.whl#sha256=339b385f50c309763ca65456ec75e17bbefcbbf2893f462cb8b90584cd27a1c2
-      - pypi: https://download.pytorch.org/whl/cu121/nvidia_cuda_runtime_cu12-12.1.105-py3-none-manylinux1_x86_64.whl#sha256=6e258468ddf5796e25f1dc591a31029fa317d97a0a94ed93468fc86301d61e40
-      - pypi: https://download.pytorch.org/whl/cu121/nvidia_cudnn_cu12-9.1.0.70-py3-none-manylinux2014_x86_64.whl#sha256=165764f44ef8c61fcdfdfdbe769d687e06374059fbb388b6c89ecb0e28793a6f
-      - pypi: https://download.pytorch.org/whl/cu121/nvidia_cufft_cu12-11.0.2.54-py3-none-manylinux1_x86_64.whl#sha256=794e3948a1aa71fd817c3775866943936774d1c14e7628c74f6f7417224cdf56
-      - pypi: https://download.pytorch.org/whl/cu121/nvidia_curand_cu12-10.3.2.106-py3-none-manylinux1_x86_64.whl#sha256=9d264c5036dde4e64f1de8c50ae753237c12e0b1348738169cd0f8a536c0e1e0
-      - pypi: https://download.pytorch.org/whl/cu121/nvidia_cusolver_cu12-11.4.5.107-py3-none-manylinux1_x86_64.whl#sha256=8a7ec542f0412294b15072fa7dab71d31334014a69f953004ea7a118206fe0dd
-      - pypi: https://download.pytorch.org/whl/cu121/nvidia_cusparse_cu12-12.1.0.106-py3-none-manylinux1_x86_64.whl#sha256=f3b50f42cf363f86ab21f720998517a659a48131e8d538dc02f8768237bd884c
-      - pypi: https://download.pytorch.org/whl/cu121/nvidia_nccl_cu12-2.21.5-py3-none-manylinux2014_x86_64.whl#sha256=8579076d30a8c24988834445f8d633c697d42397e92ffc3f63fa26766d25e0a0
-      - pypi: https://download.pytorch.org/whl/cu121/nvidia_nvjitlink_cu12-12.1.105-py3-none-manylinux1_x86_64.whl#sha256=015fed699b390ce3b8a8578d822d501a4194d0a341d3859554067c1ab291cb85
-      - pypi: https://download.pytorch.org/whl/cu121/nvidia_nvtx_cu12-12.1.105-py3-none-manylinux1_x86_64.whl#sha256=dc21cf308ca5691e7c04d962e213f8a4aa9bbfa23d95412f452254c2caeb09e5
-      - pypi: https://pypi.nvidia.com/omniverse-kit/omniverse_kit-106.1.0.140981-cp310-none-manylinux_2_34_x86_64.whl#sha256=a36fd335a6ddc0c5e3fae13bc7876b31873b6ce23fbd58a462d32f96f49d150c
+      - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2a/e2/5d3f6ada4297caebe1a2add3b126fe800c96f56dbe5d1988a2cbe0b267aa/mypy_extensions-1.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/4b/d7/ecf66c1cd12dc28b4040b15ab4d17b773b87fa9d29ca16125de01adb36cd/numpy-1.26.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/ae/71/1c91302526c45ab494c23f61c7a84aa568b8c1f9d196efa5993957faf906/nvidia_cublas_cu12-12.4.5.8-py3-none-manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/67/42/f4f60238e8194a3106d06a058d494b18e006c10bb2b915655bd9f6ea4cb1/nvidia_cuda_cupti_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/14/91ae57cd4db3f9ef7aa99f4019cfa8d54cb4caa7e00975df6467e9725a9f/nvidia_cuda_nvrtc_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/ea/27/1795d86fe88ef397885f2e580ac37628ed058a92ed2c39dc8eac3adf0619/nvidia_cuda_runtime_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/9f/fd/713452cd72343f682b1c7b9321e23829f00b842ceaedcda96e742ea0b0b3/nvidia_cudnn_cu12-9.1.0.70-py3-none-manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/27/94/3266821f65b92b3138631e9c8e7fe1fb513804ac934485a8d05776e1dd43/nvidia_cufft_cu12-11.2.1.3-py3-none-manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/8a/6d/44ad094874c6f1b9c654f8ed939590bdc408349f137f9b98a3a23ccec411/nvidia_curand_cu12-10.3.5.147-py3-none-manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/3a/e1/5b9089a4b2a4790dfdea8b3a006052cfecff58139d5a4e34cb1a51df8d6f/nvidia_cusolver_cu12-11.6.1.9-py3-none-manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/db/f7/97a9ea26ed4bbbfc2d470994b8b4f338ef663be97b8f677519ac195e113d/nvidia_cusparse_cu12-12.3.1.170-py3-none-manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/df/99/12cd266d6233f47d00daf3a72739872bdc10267d0383508b0b9c84a18bb6/nvidia_nccl_cu12-2.21.5-py3-none-manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/ff/ff/847841bacfbefc97a00036e0fce5a0f086b640756dc38caea5e1bb002655/nvidia_nvjitlink_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/87/20/199b8713428322a2f22b722c62b8cc278cc53dffa9705d744484b5035ee9/nvidia_nvtx_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/7b/e7/85b0e2897a379375e183d53c1f2b8dac76d43b4d4316e91fef80fa905799/omniverse_kit-106.1.0.140981.tar.gz
       - pypi: https://files.pythonhosted.org/packages/3f/a4/d2537f47fd7fcfba966bd806e3ec18e7ee1681056d4b0a9c8d983983e4d5/opencv_python-4.10.0.84-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ed/83/dc03ac8a478af513132024759da13b20126a4407b07ad046d9c76e2c5e55/osqp-0.6.7.post3-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://download.pytorch.org/whl/packaging-24.1-py3-none-any.whl#sha256=5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124
+      - pypi: https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl
-      - pypi: https://download.pytorch.org/whl/pillow-10.2.0-cp310-cp310-manylinux_2_28_x86_64.whl#sha256=322bdf3c9b556e9ffb18f93462e5f749d3444ce081290352c6070d014c93feb2
+      - pypi: https://files.pythonhosted.org/packages/41/c3/94f33af0762ed76b5a237c5797e088aa57f2b7fa8ee7932d399087be66a8/pillow-11.0.0-cp310-cp310-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/3c/a6/bc1012356d8ece4d66dd75c4b9fc6c1f6650ddd5991e421177d9f8f671be/platformdirs-4.3.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/58/4d/8245e6f76a93c98aab285a43ea71ff1b171bcd90c9d238bf81f7021fb233/psutil-6.1.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -112,13 +120,13 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/47/78/b0c2c23880dd1e99e938ad49ccfb011ae353758a2dc5ed7ee59baff684c3/scipy-1.14.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
-      - pypi: https://download.pytorch.org/whl/sympy-1.13.1-py3-none-any.whl#sha256=db36cdc64bf61b9b24578b6f7bab1ecdd2452cf008f34faa33776680c26d66f8
-      - pypi: https://files.pythonhosted.org/packages/cf/db/ce8eda256fa131af12e0a76d481711abe4681b6923c27efb9a255c9e4594/tomli-2.0.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b2/fe/81695a1aa331a842b582453b605175f419fe8540355886031328089d840a/sympy-1.13.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/de/f7/4da0ffe1892122c9ea096c57f64c2753ae5dd3ce85488802d11b0992cc6d/tomli-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f9/b6/a447b5e4ec71e13871be01ba81f5dfc9d0af7e473da256ff46bc0e24026f/tomlkit-0.13.2-py3-none-any.whl
-      - pypi: https://download.pytorch.org/whl/cu121/torch-2.5.1%2Bcu121-cp310-cp310-linux_x86_64.whl#sha256=92af92c569de5da937dd1afb45ecfdd598ec1254cf2e49e3d698cb24d71aae14
-      - pypi: https://download.pytorch.org/whl/triton-3.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl#sha256=6b0dd10a925263abbe9fa37dcde67a5e9b2383fc269fdf59f5657cac38c5d1d8
-      - pypi: https://download.pytorch.org/whl/typing_extensions-4.9.0-py3-none-any.whl#sha256=af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd
-      - pypi: https://download.pytorch.org/whl/urllib3-1.26.13-py2.py3-none-any.whl#sha256=47cc05d99aaa09c9e72ed5809b60e7ba354e64b59c9c173ac3018642d8bb41fc
+      - pypi: https://files.pythonhosted.org/packages/2a/ef/834af4a885b31a0b32fff2d80e1e40f771e1566ea8ded55347502440786a/torch-2.5.1-cp310-cp310-manylinux1_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/98/29/69aa56dc0b2eb2602b553881e34243475ea2afd9699be042316842788ff5/triton-3.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ce/d9/5f4c13cecde62396b0d3fe530a50ccea91e7dfc1ccf0e09c228841bb5ba8/urllib3-2.2.3-py3-none-any.whl
       - pypi: .
 packages:
 - kind: conda
@@ -229,25 +237,25 @@ packages:
   requires_python: '>=3.9'
 - kind: pypi
   name: boto3
-  version: 1.35.57
-  url: https://files.pythonhosted.org/packages/5a/b4/2aa8168bb1d80c238538ff523d8902a48b0946aafd3cbd6c72754209ae8a/boto3-1.35.57-py3-none-any.whl
-  sha256: 9edf49640c79a05b0a72f4c2d1e24dfc164344b680535a645f455ac624dc3680
+  version: 1.35.58
+  url: https://files.pythonhosted.org/packages/c6/d1/428fe22e6b0b090161a01977edab1836662b6442614f1d9ec77df99d4e6f/boto3-1.35.58-py3-none-any.whl
+  sha256: 856896fd5fc5871758eb04b27bad5bbbf0fdb6143a923f9e8d10125351efdf98
   requires_dist:
-  - botocore<1.36.0,>=1.35.57
-  - jmespath<2.0.0,>=0.7.1
-  - s3transfer<0.11.0,>=0.10.0
-  - botocore[crt]<2.0a0,>=1.21.0 ; extra == 'crt'
+  - botocore>=1.35.58,<1.36.0
+  - jmespath>=0.7.1,<2.0.0
+  - s3transfer>=0.10.0,<0.11.0
+  - botocore[crt]>=1.21.0,<2.0a0 ; extra == 'crt'
   requires_python: '>=3.8'
 - kind: pypi
   name: botocore
-  version: 1.35.57
-  url: https://files.pythonhosted.org/packages/f6/29/6c3a0f688e7c19e2a3734ab0f50cbf85138c1d7a432db8ef4f51f7bae892/botocore-1.35.57-py3-none-any.whl
-  sha256: 92ddd02469213766872cb2399269dd20948f90348b42bf08379881d5e946cc34
+  version: 1.35.58
+  url: https://files.pythonhosted.org/packages/7c/05/a09e7f96dd7875238a69963da091c8b239329cb3306fbb5af5ad6f6dfb2a/botocore-1.35.58-py3-none-any.whl
+  sha256: 647b8706ae6484ee4c2208235f38976d9f0e52f80143e81d7941075215e96111
   requires_dist:
-  - jmespath<2.0.0,>=0.7.1
-  - python-dateutil<3.0.0,>=2.1
-  - urllib3<1.27,>=1.25.4 ; python_full_version < '3.10'
-  - urllib3!=2.2.0,<3,>=1.25.4 ; python_full_version >= '3.10'
+  - jmespath>=0.7.1,<2.0.0
+  - python-dateutil>=2.1,<3.0.0
+  - urllib3>=1.25.4,<1.27 ; python_full_version < '3.10'
+  - urllib3>=1.25.4,!=2.2.0,<3 ; python_full_version >= '3.10'
   - awscrt==0.22.0 ; extra == 'crt'
   requires_python: '>=3.8'
 - kind: conda
@@ -296,9 +304,9 @@ packages:
   requires_python: '>=3.8'
 - kind: pypi
   name: contourpy
-  version: 1.3.0
-  url: https://files.pythonhosted.org/packages/99/e6/d11966962b1aa515f5586d3907ad019f4b812c04e4546cc19ebf62b5178e/contourpy-1.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  sha256: 69375194457ad0fad3a839b9e29aa0b0ed53bb54db1bfb6c3ae43d111c31ce41
+  version: 1.3.1
+  url: https://files.pythonhosted.org/packages/a9/57/86c500d63b3e26e5b73a28b8291a67c5608d4aa87ebd17bd15bb33c178bc/contourpy-1.3.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  sha256: a0cffcbede75c059f535725c1680dfb17b6ba8753f0c74b14e6a9c68c29d7ea3
   requires_dist:
   - numpy>=1.23
   - furo ; extra == 'docs'
@@ -318,7 +326,7 @@ packages:
   - pytest-rerunfailures ; extra == 'test-no-images'
   - pytest-xdist ; extra == 'test-no-images'
   - wurlitzer ; extra == 'test-no-images'
-  requires_python: '>=3.9'
+  requires_python: '>=3.10'
 - kind: pypi
   name: coverage
   version: 7.6.4
@@ -365,21 +373,23 @@ packages:
   sha256: 14de931035a41961f7c056361dc7f980762a143d05791ef5794a751a2caf05ae
 - kind: pypi
   name: filelock
-  version: 3.13.1
-  url: https://download.pytorch.org/whl/filelock-3.13.1-py3-none-any.whl#sha256=57dbda9b35157b05fb3e58ee91448612eb674172fab98ee235ccb0b5bee19a1c
-  sha256: 57dbda9b35157b05fb3e58ee91448612eb674172fab98ee235ccb0b5bee19a1c
+  version: 3.16.1
+  url: https://files.pythonhosted.org/packages/b9/f8/feced7779d755758a52d1f6635d990b8d98dc0a29fa568bbe0625f18fdf3/filelock-3.16.1-py3-none-any.whl
+  sha256: 2082e5703d51fbf98ea75855d9d5527e33d8ff23099bec374a134febee6946b0
   requires_dist:
-  - furo>=2023.9.10 ; extra == 'docs'
-  - sphinx-autodoc-typehints!=1.23.4,>=1.24 ; extra == 'docs'
-  - sphinx>=7.2.6 ; extra == 'docs'
+  - furo>=2024.8.6 ; extra == 'docs'
+  - sphinx-autodoc-typehints>=2.4.1 ; extra == 'docs'
+  - sphinx>=8.0.2 ; extra == 'docs'
   - covdefaults>=2.3 ; extra == 'testing'
-  - coverage>=7.3.2 ; extra == 'testing'
-  - diff-cover>=8 ; extra == 'testing'
-  - pytest-cov>=4.1 ; extra == 'testing'
-  - pytest-mock>=3.12 ; extra == 'testing'
-  - pytest-timeout>=2.2 ; extra == 'testing'
-  - pytest>=7.4.3 ; extra == 'testing'
-  - typing-extensions>=4.8 ; python_full_version < '3.11' and extra == 'typing'
+  - coverage>=7.6.1 ; extra == 'testing'
+  - diff-cover>=9.2 ; extra == 'testing'
+  - pytest-asyncio>=0.24 ; extra == 'testing'
+  - pytest-cov>=5 ; extra == 'testing'
+  - pytest-mock>=3.14 ; extra == 'testing'
+  - pytest-timeout>=2.3.1 ; extra == 'testing'
+  - pytest>=8.3.3 ; extra == 'testing'
+  - virtualenv>=20.26.4 ; extra == 'testing'
+  - typing-extensions>=4.12.2 ; python_full_version < '3.11' and extra == 'typing'
   requires_python: '>=3.8'
 - kind: pypi
   name: fonttools
@@ -387,7 +397,7 @@ packages:
   url: https://files.pythonhosted.org/packages/e5/12/9a45294a7c4520cc32936edd15df1d5c24af701d2f5f51070a9a43d7664b/fonttools-4.54.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: 278913a168f90d53378c20c23b80f4e599dca62fbffae4cc620c8eed476b723e
   requires_dist:
-  - fs<3,>=2.2.0 ; extra == 'all'
+  - fs>=2.2.0,<3 ; extra == 'all'
   - lxml>=4.0 ; extra == 'all'
   - zopfli>=0.1.4 ; extra == 'all'
   - lz4>=1.7.4.2 ; extra == 'all'
@@ -412,7 +422,7 @@ packages:
   - uharfbuzz>=0.23.0 ; extra == 'repacker'
   - sympy ; extra == 'symfont'
   - xattr ; sys_platform == 'darwin' and extra == 'type1'
-  - fs<3,>=2.2.0 ; extra == 'ufo'
+  - fs>=2.2.0,<3 ; extra == 'ufo'
   - unicodedata2>=15.1.0 ; python_full_version < '3.13' and extra == 'unicode'
   - zopfli>=0.1.4 ; extra == 'woff'
   - brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'woff'
@@ -420,20 +430,25 @@ packages:
   requires_python: '>=3.8'
 - kind: pypi
   name: fsspec
-  version: 2024.2.0
-  url: https://download.pytorch.org/whl/fsspec-2024.2.0-py3-none-any.whl#sha256=817f969556fa5916bc682e02ca2045f96ff7f586d45110fcb76022063ad2c7d8
-  sha256: 817f969556fa5916bc682e02ca2045f96ff7f586d45110fcb76022063ad2c7d8
+  version: 2024.10.0
+  url: https://files.pythonhosted.org/packages/c6/b2/454d6e7f0158951d8a78c2e1eb4f69ae81beb8dca5fee9809c6c99e9d0d0/fsspec-2024.10.0-py3-none-any.whl
+  sha256: 03b9a6785766a4de40368b88906366755e2819e758b83705c88cd7cb5fe81871
   requires_dist:
   - adlfs ; extra == 'abfs'
   - adlfs ; extra == 'adl'
   - pyarrow>=1 ; extra == 'arrow'
   - dask ; extra == 'dask'
   - distributed ; extra == 'dask'
-  - pytest ; extra == 'devel'
-  - pytest-cov ; extra == 'devel'
+  - pre-commit ; extra == 'dev'
+  - ruff ; extra == 'dev'
+  - numpydoc ; extra == 'doc'
+  - sphinx ; extra == 'doc'
+  - sphinx-design ; extra == 'doc'
+  - sphinx-rtd-theme ; extra == 'doc'
+  - yarl ; extra == 'doc'
+  - dropbox ; extra == 'dropbox'
   - dropboxdrivefs ; extra == 'dropbox'
   - requests ; extra == 'dropbox'
-  - dropbox ; extra == 'dropbox'
   - adlfs ; extra == 'full'
   - aiohttp!=4.0.0a0,!=4.0.0a1 ; extra == 'full'
   - dask ; extra == 'full'
@@ -466,6 +481,60 @@ packages:
   - paramiko ; extra == 'sftp'
   - smbprotocol ; extra == 'smb'
   - paramiko ; extra == 'ssh'
+  - aiohttp!=4.0.0a0,!=4.0.0a1 ; extra == 'test'
+  - numpy ; extra == 'test'
+  - pytest ; extra == 'test'
+  - pytest-asyncio!=0.22.0 ; extra == 'test'
+  - pytest-benchmark ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytest-mock ; extra == 'test'
+  - pytest-recording ; extra == 'test'
+  - pytest-rerunfailures ; extra == 'test'
+  - requests ; extra == 'test'
+  - aiobotocore>=2.5.4,<3.0.0 ; extra == 'test-downstream'
+  - dask-expr ; extra == 'test-downstream'
+  - dask[dataframe,test] ; extra == 'test-downstream'
+  - moto[server]>4,<5 ; extra == 'test-downstream'
+  - pytest-timeout ; extra == 'test-downstream'
+  - xarray ; extra == 'test-downstream'
+  - adlfs ; extra == 'test-full'
+  - aiohttp!=4.0.0a0,!=4.0.0a1 ; extra == 'test-full'
+  - cloudpickle ; extra == 'test-full'
+  - dask ; extra == 'test-full'
+  - distributed ; extra == 'test-full'
+  - dropbox ; extra == 'test-full'
+  - dropboxdrivefs ; extra == 'test-full'
+  - fastparquet ; extra == 'test-full'
+  - fusepy ; extra == 'test-full'
+  - gcsfs ; extra == 'test-full'
+  - jinja2 ; extra == 'test-full'
+  - kerchunk ; extra == 'test-full'
+  - libarchive-c ; extra == 'test-full'
+  - lz4 ; extra == 'test-full'
+  - notebook ; extra == 'test-full'
+  - numpy ; extra == 'test-full'
+  - ocifs ; extra == 'test-full'
+  - pandas ; extra == 'test-full'
+  - panel ; extra == 'test-full'
+  - paramiko ; extra == 'test-full'
+  - pyarrow ; extra == 'test-full'
+  - pyarrow>=1 ; extra == 'test-full'
+  - pyftpdlib ; extra == 'test-full'
+  - pygit2 ; extra == 'test-full'
+  - pytest ; extra == 'test-full'
+  - pytest-asyncio!=0.22.0 ; extra == 'test-full'
+  - pytest-benchmark ; extra == 'test-full'
+  - pytest-cov ; extra == 'test-full'
+  - pytest-mock ; extra == 'test-full'
+  - pytest-recording ; extra == 'test-full'
+  - pytest-rerunfailures ; extra == 'test-full'
+  - python-snappy ; extra == 'test-full'
+  - requests ; extra == 'test-full'
+  - smbprotocol ; extra == 'test-full'
+  - tqdm ; extra == 'test-full'
+  - urllib3 ; extra == 'test-full'
+  - zarr ; extra == 'test-full'
+  - zstandard ; extra == 'test-full'
   - tqdm ; extra == 'tqdm'
   requires_python: '>=3.8'
 - kind: pypi
@@ -483,7 +552,7 @@ packages:
   - box2d-py==2.3.5 ; extra == 'all'
   - pygame>=2.1.3 ; extra == 'all'
   - swig==4.* ; extra == 'all'
-  - mujoco-py<2.2,>=2.1 ; extra == 'all'
+  - mujoco-py>=2.1,<2.2 ; extra == 'all'
   - cython<3 ; extra == 'all'
   - mujoco>=2.1.5 ; extra == 'all'
   - imageio>=2.14.1 ; extra == 'all'
@@ -505,9 +574,9 @@ packages:
   - flax>=0.5.0 ; extra == 'jax'
   - mujoco>=2.1.5 ; extra == 'mujoco'
   - imageio>=2.14.1 ; extra == 'mujoco'
-  - mujoco-py<2.2,>=2.1 ; extra == 'mujoco-py'
+  - mujoco-py>=2.1,<2.2 ; extra == 'mujoco-py'
   - cython<3 ; extra == 'mujoco-py'
-  - mujoco-py<2.2,>=2.1 ; extra == 'mujoco-py'
+  - mujoco-py>=2.1,<2.2 ; extra == 'mujoco-py'
   - cython<3 ; extra == 'mujoco-py'
   - moviepy>=1.0.0 ; extra == 'other'
   - matplotlib>=3.0 ; extra == 'other'
@@ -526,7 +595,7 @@ packages:
   sha256: d30271214eae0d4758b72b408e9777405c7c7f687e14e8a42853adea887b2891
   requires_dist:
   - attrs>=22.2.0
-  - sortedcontainers<3.0.0,>=2.1.0
+  - sortedcontainers>=2.1.0,<3.0.0
   - exceptiongroup>=1.0.0 ; python_full_version < '3.11'
   - black>=19.10b0 ; extra == 'all'
   - click>=7.0 ; extra == 'all'
@@ -572,8 +641,12 @@ packages:
   name: isaac-lab-env
   version: 0.2.0
   path: .
-  sha256: ed6b09033094f57f11dc8d5dec7d41eace440d21d7965e2d42f4a67d78385711
+  sha256: 0527fcb7ab9250775eab6361dbb4f4adfa0d1403936f08b57751d0bd51b5b6c5
   requires_dist:
+  - isaacsim==4.2.0.2
+  - isaacsim-extscache-kit
+  - isaacsim-extscache-kit-sdk
+  - isaacsim-extscache-physics
   - black>=23,<=24.10.0 ; extra == 'test'
   - pylint>=3.2.5,<=3.3.1 ; extra == 'test'
   - pytest-cov>=4.1,<=6.0.0 ; extra == 'test'
@@ -581,29 +654,75 @@ packages:
   - hypothesis>=6.104.2,<=6.116.0 ; extra == 'test'
   - ruff>=0.5.0,<=0.7.2 ; extra == 'test'
   - coverage>=7.5.4,<=7.6.4 ; extra == 'test'
+  requires_python: '>=3.10,<3.11'
   editable: true
+- kind: pypi
+  name: isaacsim
+  version: 4.2.0.2
+  url: https://files.pythonhosted.org/packages/3a/ab/5049162ff8632aa960f9d0ff86c752748f89258c3cde777922a3e73aac92/isaacsim-4.2.0.2.tar.gz
+  sha256: 1827bff84ab77b955d575a3807ec162c7bab35c0536caa1be4e2cda3188d0b39
+  requires_dist:
+  - isaacsim-app==4.2.0.2
+  - isaacsim-asset==4.2.0.2
+  - isaacsim-benchmark==4.2.0.2
+  - isaacsim-code-editor==4.2.0.2
+  - isaacsim-core==4.2.0.2
+  - isaacsim-cortex==4.2.0.2
+  - isaacsim-example==4.2.0.2
+  - isaacsim-gui==4.2.0.2
+  - isaacsim-replicator==4.2.0.2
+  - isaacsim-rl==4.2.0.2
+  - isaacsim-robot==4.2.0.2
+  - isaacsim-robot-motion==4.2.0.2
+  - isaacsim-robot-setup==4.2.0.2
+  - isaacsim-ros1==4.2.0.2
+  - isaacsim-ros2==4.2.0.2
+  - isaacsim-sensor==4.2.0.2
+  - isaacsim-storage==4.2.0.2
+  - isaacsim-template==4.2.0.2
+  - isaacsim-test==4.2.0.2
+  - isaacsim-utils==4.2.0.2
+  requires_python: ==3.10.*
 - kind: pypi
   name: isaacsim-app
   version: 4.2.0.2
-  url: https://pypi.nvidia.com/isaacsim-app/isaacsim_app-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=51224da7d74179055456f7a6448e940f0a186249eaaa2b77e96f368a95dc06cb
-  sha256: 51224da7d74179055456f7a6448e940f0a186249eaaa2b77e96f368a95dc06cb
+  url: https://files.pythonhosted.org/packages/86/af/4f09ee828ef69ae5af56d95e2e139ac086d7e34c6d1468d615fcea3cb5f7/isaacsim_app-4.2.0.2.tar.gz
+  sha256: 3625420f3a1a34555f0c4ae672104d5f060df7c1b13c275e6b90eed7c93721e1
   requires_dist:
   - isaacsim-kernel==4.2.0.2
   - pyperclip
   requires_python: ==3.10.*
 - kind: pypi
+  name: isaacsim-asset
+  version: 4.2.0.2
+  url: https://files.pythonhosted.org/packages/74/4c/5c12c2a767f83031b9acbe8894beb6d13a436e7613c6ad78e98cb1900afd/isaacsim_asset-4.2.0.2.tar.gz
+  sha256: f2dc2788a789179ce8d833519c24eab9e5688e002027e8bc09749c0d0ea1e4b1
+  requires_dist:
+  - isaacsim-utils==4.2.0.2
+  - isaacsim-storage==4.2.0.2
+  - pillow
+  requires_python: ==3.10.*
+- kind: pypi
   name: isaacsim-benchmark
   version: 4.2.0.2
-  url: https://pypi.nvidia.com/isaacsim-benchmark/isaacsim_benchmark-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=2de38ae6a6fc0637fa12bc29f668f3f04dad6f7c639a370b0300a48c174c098d
-  sha256: 2de38ae6a6fc0637fa12bc29f668f3f04dad6f7c639a370b0300a48c174c098d
+  url: https://files.pythonhosted.org/packages/86/f3/79eb20eef8e5cfd6741281c5188d7a621db2ce8bbcf18ac8d215abf1f6b7/isaacsim_benchmark-4.2.0.2.tar.gz
+  sha256: 41157eca49e4d37d5b40537b83cb461359979b2f6e846a42e63e2c700ff8b855
   requires_dist:
   - isaacsim-robot==4.2.0.2
   requires_python: ==3.10.*
 - kind: pypi
+  name: isaacsim-code-editor
+  version: 4.2.0.2
+  url: https://files.pythonhosted.org/packages/1e/a2/3cd3c4bba8919d37a53d05dfb72849061ebd05bbc51e18b64f74c1c15556/isaacsim_code_editor-4.2.0.2.tar.gz
+  sha256: 5485b86a37382d6109b6512fc6beb4287a60d1170ba19af9ad656e3e095dc9f5
+  requires_dist:
+  - isaacsim-kernel==4.2.0.2
+  requires_python: ==3.10.*
+- kind: pypi
   name: isaacsim-core
   version: 4.2.0.2
-  url: https://pypi.nvidia.com/isaacsim-core/isaacsim_core-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=ca73ce9d2ff9d693cd8fcf44e67569a2e0cbc44009e58c39506bc851d23ad2a6
-  sha256: ca73ce9d2ff9d693cd8fcf44e67569a2e0cbc44009e58c39506bc851d23ad2a6
+  url: https://files.pythonhosted.org/packages/97/10/d803f41166f0d95ded6d74e696ba144a01063cee1058afd75cf22c87436e/isaacsim_core-4.2.0.2.tar.gz
+  sha256: 9b80ca2e2fdddad877cc9a8c293ed75f84e14bbe8ff7d59494aa6b5b5ad8a4f9
   requires_dist:
   - isaacsim-kernel==4.2.0.2
   - numpy<2.0.0
@@ -616,44 +735,61 @@ packages:
   - pyyaml
   requires_python: ==3.10.*
 - kind: pypi
+  name: isaacsim-cortex
+  version: 4.2.0.2
+  url: https://files.pythonhosted.org/packages/30/29/304ba9973d154fbb1eed8303b497f3f768d1f1ddde5a3bad63173c8c8e39/isaacsim_cortex-4.2.0.2.tar.gz
+  sha256: 5d675dbb88f159fcd78dde2041a4e91a0ab2afc3f17cf5a4368b7ff3a535c744
+  requires_dist:
+  - isaacsim-robot==4.2.0.2
+  - isaacsim-ros1==4.2.0.2
+  requires_python: ==3.10.*
+- kind: pypi
+  name: isaacsim-example
+  version: 4.2.0.2
+  url: https://files.pythonhosted.org/packages/a6/3c/4f44601b95dbda015ba02b49ba19b4abe7c04259d978809e40fb6d3fb1e1/isaacsim_example-4.2.0.2.tar.gz
+  sha256: 5b29b8c3f8143a01926ed23f8febfd0a3f036f24902d4ec8b0b7288507f82758
+  requires_dist:
+  - isaacsim-cortex==4.2.0.2
+  requires_python: ==3.10.*
+- kind: pypi
   name: isaacsim-extscache-kit
   version: 4.2.0.2
-  url: https://pypi.nvidia.com/isaacsim-extscache-kit/isaacsim_extscache_kit-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=2ff59ec1c8fedc7505aff54d6e1a2c15739874307a97effd33680ef27f973c7a
-  sha256: 2ff59ec1c8fedc7505aff54d6e1a2c15739874307a97effd33680ef27f973c7a
+  url: https://files.pythonhosted.org/packages/e1/51/932ca6b7ae104f2be2fe3ba3372488975625d038c739b38a16bbd45c3f04/isaacsim_extscache_kit-4.2.0.2.tar.gz
+  sha256: b73bfc39a4acebc56b76445190933d598c37b54744aab5fed045c953e9660485
   requires_python: ==3.10.*
 - kind: pypi
   name: isaacsim-extscache-kit-sdk
   version: 4.2.0.2
-  url: https://pypi.nvidia.com/isaacsim-extscache-kit-sdk/isaacsim_extscache_kit_sdk-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=edceebb3325b3c4bdaf1e5b19bb1251c895daaf59348990726bfee3ca0ce7e60
-  sha256: edceebb3325b3c4bdaf1e5b19bb1251c895daaf59348990726bfee3ca0ce7e60
+  url: https://files.pythonhosted.org/packages/d5/4d/43b95048e4f7fe5ffe671903e12acbc890996ec48fc81d40faa4d5faead0/isaacsim_extscache_kit_sdk-4.2.0.2.tar.gz
+  sha256: 12227a410f10cec837dcdc84397b09d15298bf9b6a8323eaabb45efff9488189
   requires_python: ==3.10.*
 - kind: pypi
   name: isaacsim-extscache-physics
   version: 4.2.0.2
-  url: https://pypi.nvidia.com/isaacsim-extscache-physics/isaacsim_extscache_physics-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=61f13f6d1b0aeef9ab522a7c3c7ffd414ac390840ae855a80fa49d558990481b
-  sha256: 61f13f6d1b0aeef9ab522a7c3c7ffd414ac390840ae855a80fa49d558990481b
+  url: https://files.pythonhosted.org/packages/26/39/f1e9d9b87222969ba456d485e39644fdfb57e99a77f075e82acea0b67b1f/isaacsim_extscache_physics-4.2.0.2.tar.gz
+  sha256: 6555bc86103a330d5527641e5792302e6b1d30808f0225c3af24d33c9a7d66df
   requires_python: ==3.10.*
 - kind: pypi
   name: isaacsim-gui
   version: 4.2.0.2
-  url: https://pypi.nvidia.com/isaacsim-gui/isaacsim_gui-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=0fa88e3613499670a45dbda745ebc486426b2bafa4c868ce23e44e7396095f66
-  sha256: 0fa88e3613499670a45dbda745ebc486426b2bafa4c868ce23e44e7396095f66
+  url: https://files.pythonhosted.org/packages/a7/26/3c6f3c1c3020048d0b952b4e8aee89c572af3c38211d5ae9e8d2f44fb9c6/isaacsim_gui-4.2.0.2.tar.gz
+  sha256: 5f0f429fff228814c8c2b15e823cda634b6d303c2fd35b506a1012d3f6438981
   requires_dist:
   - isaacsim-core==4.2.0.2
   requires_python: ==3.10.*
 - kind: pypi
   name: isaacsim-kernel
   version: 4.2.0.2
-  url: https://pypi.nvidia.com/isaacsim-kernel/isaacsim_kernel-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=8c44f6e4a32b160682f148e098fe8fe9aec4406d2c203e6f0b0c3b48bd46313e
-  sha256: 8c44f6e4a32b160682f148e098fe8fe9aec4406d2c203e6f0b0c3b48bd46313e
+  url: https://files.pythonhosted.org/packages/e4/ec/e1c4278e4abe0208b5f391761be8301c27f0ebab555155485fc0c7bdd54e/isaacsim_kernel-4.2.0.2.tar.gz
+  sha256: 4a9c3964321811266d741ffe46427d117d7923ab423683b02866a99dead870c3
   requires_dist:
   - omniverse-kit==106.1.0.140981
   requires_python: ==3.10.*
 - kind: pypi
   name: isaacsim-replicator
   version: 4.2.0.2
-  url: https://pypi.nvidia.com/isaacsim-replicator/isaacsim_replicator-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=49e5cad782ee40db1735325278640dc9627d64d71d7a7eded053c0969dc48023
-  sha256: 49e5cad782ee40db1735325278640dc9627d64d71d7a7eded053c0969dc48023
+  url: https://files.pythonhosted.org/packages/e4/62/d717e8d687efcd26e20730ad2dd7229b907d1e9d86f92a63aad4bf8ad9fe/isaacsim_replicator-4.2.0.2.tar.gz
+  sha256: 0148d003381f9f3b418df5b6d65ebbecd6b0b3e486577fc11c988b9212307e9f
   requires_dist:
   - isaacsim-core==4.2.0.2
   - isaacsim-storage==4.2.0.2
@@ -662,8 +798,8 @@ packages:
 - kind: pypi
   name: isaacsim-rl
   version: 4.2.0.2
-  url: https://pypi.nvidia.com/isaacsim-rl/isaacsim_rl-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=8297cde072f44087192f8db909bab2d4777dd6e9abc130d30796a9f812439401
-  sha256: 8297cde072f44087192f8db909bab2d4777dd6e9abc130d30796a9f812439401
+  url: https://files.pythonhosted.org/packages/ad/34/f4d76df53c9210543290bc302b5a11220c556639c0189bc02a323459c091/isaacsim_rl-4.2.0.2.tar.gz
+  sha256: bbf8e48bd0222472cac18111f445f55d5657696216d0240eccab4d8c129a34c8
   requires_dist:
   - isaacsim-robot==4.2.0.2
   - isaacsim-benchmark==4.2.0.2
@@ -672,8 +808,8 @@ packages:
 - kind: pypi
   name: isaacsim-robot
   version: 4.2.0.2
-  url: https://pypi.nvidia.com/isaacsim-robot/isaacsim_robot-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=b17a028d88e364d1b8810c6fa855b4e7fc35b804554adad459ea84cb2696ed29
-  sha256: b17a028d88e364d1b8810c6fa855b4e7fc35b804554adad459ea84cb2696ed29
+  url: https://files.pythonhosted.org/packages/5f/44/72dd6184e73ced8aafea52bf8cb33b30e5b596e3375b0446e98de27acab3/isaacsim_robot-4.2.0.2.tar.gz
+  sha256: b02c443e11bba28f6ed5a4311a0d98d5ccc6970b1ffc0e5f7166a3c2740b6694
   requires_dist:
   - isaacsim-sensor==4.2.0.2
   - isaacsim-robot-motion==4.2.0.2
@@ -682,16 +818,40 @@ packages:
 - kind: pypi
   name: isaacsim-robot-motion
   version: 4.2.0.2
-  url: https://pypi.nvidia.com/isaacsim-robot-motion/isaacsim_robot_motion-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=e72b6b5126f9f04cf3b401ec33b1712963b4afc2d8081822cf405288e98c19a7
-  sha256: e72b6b5126f9f04cf3b401ec33b1712963b4afc2d8081822cf405288e98c19a7
+  url: https://files.pythonhosted.org/packages/74/8e/2d3b86995f000dc7ce9166b1848d4469866524ad129f192384685dc4847b/isaacsim_robot_motion-4.2.0.2.tar.gz
+  sha256: 403ad004a25beb86f3855a50cec660d3d1fad5bf7ec14fbef850ccdaed26ba0a
   requires_dist:
   - isaacsim-gui==4.2.0.2
   requires_python: ==3.10.*
 - kind: pypi
+  name: isaacsim-robot-setup
+  version: 4.2.0.2
+  url: https://files.pythonhosted.org/packages/88/b2/f6faa50ddad1285549483b4e1e7ae52c3a3c455a3073eb394878ceb34a6e/isaacsim_robot_setup-4.2.0.2.tar.gz
+  sha256: 82b5cd763073454c8ad89057242fcf8b389cf2ea0f3f7446b781ceca0a499fe6
+  requires_dist:
+  - isaacsim-robot-motion==4.2.0.2
+  requires_python: ==3.10.*
+- kind: pypi
+  name: isaacsim-ros1
+  version: 4.2.0.2
+  url: https://files.pythonhosted.org/packages/43/52/73d5c6a7eaf3cc789bff60bed4eec14b3dbb070066a8d20c07f946b67170/isaacsim_ros1-4.2.0.2.tar.gz
+  sha256: 04ede26284332c805adc91afd3b1c42ac38ea630fc036a7c6ea1273b08a74d36
+  requires_dist:
+  - isaacsim-sensor==4.2.0.2
+  requires_python: ==3.10.*
+- kind: pypi
+  name: isaacsim-ros2
+  version: 4.2.0.2
+  url: https://files.pythonhosted.org/packages/64/69/3e158a209402fac1b10cb92fac62e1ef9e6ec3f1a41a72016e357e525dff/isaacsim_ros2-4.2.0.2.tar.gz
+  sha256: 2b5b40f6944abe8f4fe0404b7834cbea3464dededdca90d74ff5221a5ea869e4
+  requires_dist:
+  - isaacsim-sensor==4.2.0.2
+  requires_python: ==3.10.*
+- kind: pypi
   name: isaacsim-sensor
   version: 4.2.0.2
-  url: https://pypi.nvidia.com/isaacsim-sensor/isaacsim_sensor-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=521d4bed279aa6b79d5c82d87d6702f605d9c058bcda876c1e8dffa1ed1468e7
-  sha256: 521d4bed279aa6b79d5c82d87d6702f605d9c058bcda876c1e8dffa1ed1468e7
+  url: https://files.pythonhosted.org/packages/d2/dc/4640155628e73a99053e0cc481367c6f9e2f031f0b5d1ee41a0d96bd43a5/isaacsim_sensor-4.2.0.2.tar.gz
+  sha256: a72fc4a0d41ce2ba9a66e87bcc319789ab98b7a2aba0506e782c867148200325
   requires_dist:
   - isaacsim-utils==4.2.0.2
   - isaacsim-gui==4.2.0.2
@@ -701,16 +861,33 @@ packages:
 - kind: pypi
   name: isaacsim-storage
   version: 4.2.0.2
-  url: https://pypi.nvidia.com/isaacsim-storage/isaacsim_storage-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=06c5847bfe373aee0073bd29b33a352e7c7bdfa9083de1967e6a6fac75ef7eea
-  sha256: 06c5847bfe373aee0073bd29b33a352e7c7bdfa9083de1967e6a6fac75ef7eea
+  url: https://files.pythonhosted.org/packages/a5/3d/c21377ed8b1bf1a6f2c3ef146652f48134308e9807f6a573711acaea489e/isaacsim_storage-4.2.0.2.tar.gz
+  sha256: 8ef8a94cd735e4834fd7bc0f43f89e47975704dd34cf9d19cdafed7fc3358edd
   requires_dist:
   - isaacsim-kernel==4.2.0.2
   requires_python: ==3.10.*
 - kind: pypi
+  name: isaacsim-template
+  version: 4.2.0.2
+  url: https://files.pythonhosted.org/packages/32/2c/4fd0f5d8e7ef8f57417a41bea4653d8d1439a0c30abf25b3b0d3c009421e/isaacsim_template-4.2.0.2.tar.gz
+  sha256: b888520315ef7545f4714ef37dea53221d57a0ba79705d9366817100bc440a8f
+  requires_dist:
+  - isaacsim-storage==4.2.0.2
+  - isaacsim-gui==4.2.0.2
+  requires_python: ==3.10.*
+- kind: pypi
+  name: isaacsim-test
+  version: 4.2.0.2
+  url: https://files.pythonhosted.org/packages/45/43/bc69acaf8ea438e1f2424bf7f9226c9a0caefa658f9e05bd992a96b1b42b/isaacsim_test-4.2.0.2.tar.gz
+  sha256: 64871c8eb593dcdba8f51f769b38b226b13504246c9b645471e89868ce00b44a
+  requires_dist:
+  - isaacsim-robot==4.2.0.2
+  requires_python: ==3.10.*
+- kind: pypi
   name: isaacsim-utils
   version: 4.2.0.2
-  url: https://pypi.nvidia.com/isaacsim-utils/isaacsim_utils-4.2.0.2-cp310-none-manylinux_2_34_x86_64.whl#sha256=bf787163d85f182d08b8bd5dd61e21909c52c979cca44cb4ee06777ecdb443df
-  sha256: bf787163d85f182d08b8bd5dd61e21909c52c979cca44cb4ee06777ecdb443df
+  url: https://files.pythonhosted.org/packages/a1/0d/a9247259dc72262c7d5fdca71aa774989721cc9a58b5ea418ac179e1f29e/isaacsim_utils-4.2.0.2.tar.gz
+  sha256: abab794e60e4abd296f65d0bc031557135f0d427bf501b951e1e04984c3cb28b
   requires_dist:
   - isaacsim-gui==4.2.0.2
   requires_python: ==3.10.*
@@ -724,9 +901,9 @@ packages:
   requires_python: '>=3.8.0'
 - kind: pypi
   name: jinja2
-  version: 3.1.3
-  url: https://download.pytorch.org/whl/Jinja2-3.1.3-py3-none-any.whl#sha256=7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa
-  sha256: 7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa
+  version: 3.1.4
+  url: https://files.pythonhosted.org/packages/31/80/3a54838c3fb461f6fec263ebf3a3a41771bd05190238de3486aae8540c36/jinja2-3.1.4-py3-none-any.whl
+  sha256: bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d
   requires_dist:
   - markupsafe>=2.0
   - babel>=2.7 ; extra == 'i18n'
@@ -912,10 +1089,10 @@ packages:
   timestamp: 1727963148474
 - kind: pypi
   name: markupsafe
-  version: 2.1.5
-  url: https://download.pytorch.org/whl/MarkupSafe-2.1.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl#sha256=2174c595a0d73a3080ca3257b40096db99799265e1c27cc5a610743acd86d62f
-  sha256: 2174c595a0d73a3080ca3257b40096db99799265e1c27cc5a610743acd86d62f
-  requires_python: '>=3.7'
+  version: 3.0.2
+  url: https://files.pythonhosted.org/packages/22/35/137da042dfb4720b638d2937c38a9c2df83fe32d20e8c8f3185dbfef05f7/MarkupSafe-3.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  sha256: bbcb445fa71794da8f178f0f6d66789a28d7319071af7a496d4d507ed566270d
+  requires_python: '>=3.9'
 - kind: pypi
   name: matplotlib
   version: 3.9.2
@@ -947,7 +1124,7 @@ packages:
 - kind: pypi
   name: mpmath
   version: 1.3.0
-  url: https://download.pytorch.org/whl/mpmath-1.3.0-py3-none-any.whl#sha256=a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c
+  url: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
   sha256: a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c
   requires_dist:
   - pytest>=4.6 ; extra == 'develop'
@@ -961,7 +1138,7 @@ packages:
 - kind: pypi
   name: mypy-extensions
   version: 1.0.0
-  url: https://download.pytorch.org/whl/mypy_extensions-1.0.0-py3-none-any.whl#sha256=4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d
+  url: https://files.pythonhosted.org/packages/2a/e2/5d3f6ada4297caebe1a2add3b126fe800c96f56dbe5d1988a2cbe0b267aa/mypy_extensions-1.0.0-py3-none-any.whl
   sha256: 4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d
   requires_python: '>=3.5'
 - kind: conda
@@ -982,88 +1159,95 @@ packages:
   timestamp: 1724658547447
 - kind: pypi
   name: networkx
-  version: 3.2.1
-  url: https://download.pytorch.org/whl/networkx-3.2.1-py3-none-any.whl#sha256=f18c69adc97877c42332c170849c96cefa91881c99a7cb3e95b7c659ebdc1ec2
-  sha256: f18c69adc97877c42332c170849c96cefa91881c99a7cb3e95b7c659ebdc1ec2
+  version: 3.4.2
+  url: https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl
+  sha256: df5d4365b724cf81b8c6a7312509d0c22386097011ad1abe274afd5e9d3bbc5f
   requires_dist:
-  - numpy>=1.22 ; extra == 'default'
-  - scipy!=1.11.0,!=1.11.1,>=1.9 ; extra == 'default'
-  - matplotlib>=3.5 ; extra == 'default'
-  - pandas>=1.4 ; extra == 'default'
-  - changelist==0.4 ; extra == 'developer'
+  - numpy>=1.24 ; extra == 'default'
+  - scipy>=1.10,!=1.11.0,!=1.11.1 ; extra == 'default'
+  - matplotlib>=3.7 ; extra == 'default'
+  - pandas>=2.0 ; extra == 'default'
+  - changelist==0.5 ; extra == 'developer'
   - pre-commit>=3.2 ; extra == 'developer'
   - mypy>=1.1 ; extra == 'developer'
   - rtoml ; extra == 'developer'
-  - sphinx>=7 ; extra == 'doc'
-  - pydata-sphinx-theme>=0.14 ; extra == 'doc'
-  - sphinx-gallery>=0.14 ; extra == 'doc'
-  - numpydoc>=1.6 ; extra == 'doc'
+  - sphinx>=7.3 ; extra == 'doc'
+  - pydata-sphinx-theme>=0.15 ; extra == 'doc'
+  - sphinx-gallery>=0.16 ; extra == 'doc'
+  - numpydoc>=1.8.0 ; extra == 'doc'
   - pillow>=9.4 ; extra == 'doc'
-  - nb2plots>=0.7 ; extra == 'doc'
   - texext>=0.6.7 ; extra == 'doc'
-  - nbconvert<7.9 ; extra == 'doc'
+  - myst-nb>=1.1 ; extra == 'doc'
+  - intersphinx-registry ; extra == 'doc'
+  - osmnx>=1.9 ; extra == 'example'
+  - momepy>=0.7.2 ; extra == 'example'
+  - contextily>=1.6 ; extra == 'example'
+  - seaborn>=0.13 ; extra == 'example'
+  - cairocffi>=1.7 ; extra == 'example'
+  - igraph>=0.11 ; extra == 'example'
+  - scikit-learn>=1.5 ; extra == 'example'
   - lxml>=4.6 ; extra == 'extra'
-  - pygraphviz>=1.11 ; extra == 'extra'
-  - pydot>=1.4.2 ; extra == 'extra'
+  - pygraphviz>=1.14 ; extra == 'extra'
+  - pydot>=3.0.1 ; extra == 'extra'
   - sympy>=1.10 ; extra == 'extra'
   - pytest>=7.2 ; extra == 'test'
   - pytest-cov>=4.0 ; extra == 'test'
-  requires_python: '>=3.9'
+  requires_python: '>=3.10'
 - kind: pypi
   name: numpy
-  version: 1.26.3
-  url: https://download.pytorch.org/whl/numpy-1.26.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl#sha256=bdd2b45bf079d9ad90377048e2747a0c82351989a2165821f0c96831b4a2a54b
-  sha256: bdd2b45bf079d9ad90377048e2747a0c82351989a2165821f0c96831b4a2a54b
+  version: 1.26.4
+  url: https://files.pythonhosted.org/packages/4b/d7/ecf66c1cd12dc28b4040b15ab4d17b773b87fa9d29ca16125de01adb36cd/numpy-1.26.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  sha256: ffa75af20b44f8dba823498024771d5ac50620e6915abac414251bd971b4529f
   requires_python: '>=3.9'
 - kind: pypi
   name: nvidia-cublas-cu12
-  version: 12.1.3.1
-  url: https://download.pytorch.org/whl/cu121/nvidia_cublas_cu12-12.1.3.1-py3-none-manylinux1_x86_64.whl#sha256=ee53ccca76a6fc08fb9701aa95b6ceb242cdaab118c3bb152af4e579af792728
-  sha256: ee53ccca76a6fc08fb9701aa95b6ceb242cdaab118c3bb152af4e579af792728
+  version: 12.4.5.8
+  url: https://files.pythonhosted.org/packages/ae/71/1c91302526c45ab494c23f61c7a84aa568b8c1f9d196efa5993957faf906/nvidia_cublas_cu12-12.4.5.8-py3-none-manylinux2014_x86_64.whl
+  sha256: 2fc8da60df463fdefa81e323eef2e36489e1c94335b5358bcb38360adf75ac9b
   requires_python: '>=3'
 - kind: pypi
   name: nvidia-cuda-cupti-cu12
-  version: 12.1.105
-  url: https://download.pytorch.org/whl/cu121/nvidia_cuda_cupti_cu12-12.1.105-py3-none-manylinux1_x86_64.whl#sha256=e54fde3983165c624cb79254ae9818a456eb6e87a7fd4d56a2352c24ee542d7e
-  sha256: e54fde3983165c624cb79254ae9818a456eb6e87a7fd4d56a2352c24ee542d7e
+  version: 12.4.127
+  url: https://files.pythonhosted.org/packages/67/42/f4f60238e8194a3106d06a058d494b18e006c10bb2b915655bd9f6ea4cb1/nvidia_cuda_cupti_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl
+  sha256: 9dec60f5ac126f7bb551c055072b69d85392b13311fcc1bcda2202d172df30fb
   requires_python: '>=3'
 - kind: pypi
   name: nvidia-cuda-nvrtc-cu12
-  version: 12.1.105
-  url: https://download.pytorch.org/whl/cu121/nvidia_cuda_nvrtc_cu12-12.1.105-py3-none-manylinux1_x86_64.whl#sha256=339b385f50c309763ca65456ec75e17bbefcbbf2893f462cb8b90584cd27a1c2
-  sha256: 339b385f50c309763ca65456ec75e17bbefcbbf2893f462cb8b90584cd27a1c2
+  version: 12.4.127
+  url: https://files.pythonhosted.org/packages/2c/14/91ae57cd4db3f9ef7aa99f4019cfa8d54cb4caa7e00975df6467e9725a9f/nvidia_cuda_nvrtc_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl
+  sha256: a178759ebb095827bd30ef56598ec182b85547f1508941a3d560eb7ea1fbf338
   requires_python: '>=3'
 - kind: pypi
   name: nvidia-cuda-runtime-cu12
-  version: 12.1.105
-  url: https://download.pytorch.org/whl/cu121/nvidia_cuda_runtime_cu12-12.1.105-py3-none-manylinux1_x86_64.whl#sha256=6e258468ddf5796e25f1dc591a31029fa317d97a0a94ed93468fc86301d61e40
-  sha256: 6e258468ddf5796e25f1dc591a31029fa317d97a0a94ed93468fc86301d61e40
+  version: 12.4.127
+  url: https://files.pythonhosted.org/packages/ea/27/1795d86fe88ef397885f2e580ac37628ed058a92ed2c39dc8eac3adf0619/nvidia_cuda_runtime_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl
+  sha256: 64403288fa2136ee8e467cdc9c9427e0434110899d07c779f25b5c068934faa5
   requires_python: '>=3'
 - kind: pypi
   name: nvidia-cudnn-cu12
   version: 9.1.0.70
-  url: https://download.pytorch.org/whl/cu121/nvidia_cudnn_cu12-9.1.0.70-py3-none-manylinux2014_x86_64.whl#sha256=165764f44ef8c61fcdfdfdbe769d687e06374059fbb388b6c89ecb0e28793a6f
+  url: https://files.pythonhosted.org/packages/9f/fd/713452cd72343f682b1c7b9321e23829f00b842ceaedcda96e742ea0b0b3/nvidia_cudnn_cu12-9.1.0.70-py3-none-manylinux2014_x86_64.whl
   sha256: 165764f44ef8c61fcdfdfdbe769d687e06374059fbb388b6c89ecb0e28793a6f
   requires_dist:
   - nvidia-cublas-cu12
   requires_python: '>=3'
 - kind: pypi
   name: nvidia-cufft-cu12
-  version: 11.0.2.54
-  url: https://download.pytorch.org/whl/cu121/nvidia_cufft_cu12-11.0.2.54-py3-none-manylinux1_x86_64.whl#sha256=794e3948a1aa71fd817c3775866943936774d1c14e7628c74f6f7417224cdf56
-  sha256: 794e3948a1aa71fd817c3775866943936774d1c14e7628c74f6f7417224cdf56
+  version: 11.2.1.3
+  url: https://files.pythonhosted.org/packages/27/94/3266821f65b92b3138631e9c8e7fe1fb513804ac934485a8d05776e1dd43/nvidia_cufft_cu12-11.2.1.3-py3-none-manylinux2014_x86_64.whl
+  sha256: f083fc24912aa410be21fa16d157fed2055dab1cc4b6934a0e03cba69eb242b9
   requires_python: '>=3'
 - kind: pypi
   name: nvidia-curand-cu12
-  version: 10.3.2.106
-  url: https://download.pytorch.org/whl/cu121/nvidia_curand_cu12-10.3.2.106-py3-none-manylinux1_x86_64.whl#sha256=9d264c5036dde4e64f1de8c50ae753237c12e0b1348738169cd0f8a536c0e1e0
-  sha256: 9d264c5036dde4e64f1de8c50ae753237c12e0b1348738169cd0f8a536c0e1e0
+  version: 10.3.5.147
+  url: https://files.pythonhosted.org/packages/8a/6d/44ad094874c6f1b9c654f8ed939590bdc408349f137f9b98a3a23ccec411/nvidia_curand_cu12-10.3.5.147-py3-none-manylinux2014_x86_64.whl
+  sha256: a88f583d4e0bb643c49743469964103aa59f7f708d862c3ddb0fc07f851e3b8b
   requires_python: '>=3'
 - kind: pypi
   name: nvidia-cusolver-cu12
-  version: 11.4.5.107
-  url: https://download.pytorch.org/whl/cu121/nvidia_cusolver_cu12-11.4.5.107-py3-none-manylinux1_x86_64.whl#sha256=8a7ec542f0412294b15072fa7dab71d31334014a69f953004ea7a118206fe0dd
-  sha256: 8a7ec542f0412294b15072fa7dab71d31334014a69f953004ea7a118206fe0dd
+  version: 11.6.1.9
+  url: https://files.pythonhosted.org/packages/3a/e1/5b9089a4b2a4790dfdea8b3a006052cfecff58139d5a4e34cb1a51df8d6f/nvidia_cusolver_cu12-11.6.1.9-py3-none-manylinux2014_x86_64.whl
+  sha256: 19e33fa442bcfd085b3086c4ebf7e8debc07cfe01e11513cc6d332fd918ac260
   requires_dist:
   - nvidia-cublas-cu12
   - nvidia-nvjitlink-cu12
@@ -1071,35 +1255,35 @@ packages:
   requires_python: '>=3'
 - kind: pypi
   name: nvidia-cusparse-cu12
-  version: 12.1.0.106
-  url: https://download.pytorch.org/whl/cu121/nvidia_cusparse_cu12-12.1.0.106-py3-none-manylinux1_x86_64.whl#sha256=f3b50f42cf363f86ab21f720998517a659a48131e8d538dc02f8768237bd884c
-  sha256: f3b50f42cf363f86ab21f720998517a659a48131e8d538dc02f8768237bd884c
+  version: 12.3.1.170
+  url: https://files.pythonhosted.org/packages/db/f7/97a9ea26ed4bbbfc2d470994b8b4f338ef663be97b8f677519ac195e113d/nvidia_cusparse_cu12-12.3.1.170-py3-none-manylinux2014_x86_64.whl
+  sha256: ea4f11a2904e2a8dc4b1833cc1b5181cde564edd0d5cd33e3c168eff2d1863f1
   requires_dist:
   - nvidia-nvjitlink-cu12
   requires_python: '>=3'
 - kind: pypi
   name: nvidia-nccl-cu12
   version: 2.21.5
-  url: https://download.pytorch.org/whl/cu121/nvidia_nccl_cu12-2.21.5-py3-none-manylinux2014_x86_64.whl#sha256=8579076d30a8c24988834445f8d633c697d42397e92ffc3f63fa26766d25e0a0
+  url: https://files.pythonhosted.org/packages/df/99/12cd266d6233f47d00daf3a72739872bdc10267d0383508b0b9c84a18bb6/nvidia_nccl_cu12-2.21.5-py3-none-manylinux2014_x86_64.whl
   sha256: 8579076d30a8c24988834445f8d633c697d42397e92ffc3f63fa26766d25e0a0
   requires_python: '>=3'
 - kind: pypi
   name: nvidia-nvjitlink-cu12
-  version: 12.1.105
-  url: https://download.pytorch.org/whl/cu121/nvidia_nvjitlink_cu12-12.1.105-py3-none-manylinux1_x86_64.whl#sha256=015fed699b390ce3b8a8578d822d501a4194d0a341d3859554067c1ab291cb85
-  sha256: 015fed699b390ce3b8a8578d822d501a4194d0a341d3859554067c1ab291cb85
+  version: 12.4.127
+  url: https://files.pythonhosted.org/packages/ff/ff/847841bacfbefc97a00036e0fce5a0f086b640756dc38caea5e1bb002655/nvidia_nvjitlink_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl
+  sha256: 06b3b9b25bf3f8af351d664978ca26a16d2c5127dbd53c0497e28d1fb9611d57
   requires_python: '>=3'
 - kind: pypi
   name: nvidia-nvtx-cu12
-  version: 12.1.105
-  url: https://download.pytorch.org/whl/cu121/nvidia_nvtx_cu12-12.1.105-py3-none-manylinux1_x86_64.whl#sha256=dc21cf308ca5691e7c04d962e213f8a4aa9bbfa23d95412f452254c2caeb09e5
-  sha256: dc21cf308ca5691e7c04d962e213f8a4aa9bbfa23d95412f452254c2caeb09e5
+  version: 12.4.127
+  url: https://files.pythonhosted.org/packages/87/20/199b8713428322a2f22b722c62b8cc278cc53dffa9705d744484b5035ee9/nvidia_nvtx_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl
+  sha256: 781e950d9b9f60d8241ccea575b32f5105a5baf4c2351cab5256a24869f12a1a
   requires_python: '>=3'
 - kind: pypi
   name: omniverse-kit
   version: 106.1.0.140981
-  url: https://pypi.nvidia.com/omniverse-kit/omniverse_kit-106.1.0.140981-cp310-none-manylinux_2_34_x86_64.whl#sha256=a36fd335a6ddc0c5e3fae13bc7876b31873b6ce23fbd58a462d32f96f49d150c
-  sha256: a36fd335a6ddc0c5e3fae13bc7876b31873b6ce23fbd58a462d32f96f49d150c
+  url: https://files.pythonhosted.org/packages/7b/e7/85b0e2897a379375e183d53c1f2b8dac76d43b4d4316e91fef80fa905799/omniverse_kit-106.1.0.140981.tar.gz
+  sha256: 00570da637a465c2d6d9f9950e9eb9cac2a10f14879c48eb77f475c19cdf3b2d
   requires_python: ==3.10.*
 - kind: pypi
   name: opencv-python
@@ -1120,12 +1304,12 @@ packages:
   requires_python: '>=3.6'
 - kind: conda
   name: openssl
-  version: 3.3.2
+  version: 3.4.0
   build: hb9d3cd8_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.2-hb9d3cd8_0.conda
-  sha256: cee91036686419f6dd6086902acf7142b4916e1c4ba042e9ca23e151da012b6d
-  md5: 4d638782050ab6faa27275bed57e9b4e
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.0-hb9d3cd8_0.conda
+  sha256: 814b9dff1847b132c676ee6cc1a8cb2d427320779b93e1b6d76552275c128705
+  md5: 23cc74f77eb99315c0360ec3533147a9
   depends:
   - __glibc >=2.17,<3.0.a0
   - ca-certificates
@@ -1133,8 +1317,8 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 2891789
-  timestamp: 1725410790053
+  size: 2947466
+  timestamp: 1731377666602
 - kind: pypi
   name: osqp
   version: 0.6.7.post3
@@ -1147,9 +1331,9 @@ packages:
   - scipy!=1.12.0 ; extra == 'dev'
 - kind: pypi
   name: packaging
-  version: '24.1'
-  url: https://download.pytorch.org/whl/packaging-24.1-py3-none-any.whl#sha256=5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124
-  sha256: 5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124
+  version: '24.2'
+  url: https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl
+  sha256: 09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759
   requires_python: '>=3.8'
 - kind: pypi
   name: pathspec
@@ -1159,16 +1343,15 @@ packages:
   requires_python: '>=3.8'
 - kind: pypi
   name: pillow
-  version: 10.2.0
-  url: https://download.pytorch.org/whl/pillow-10.2.0-cp310-cp310-manylinux_2_28_x86_64.whl#sha256=322bdf3c9b556e9ffb18f93462e5f749d3444ce081290352c6070d014c93feb2
-  sha256: 322bdf3c9b556e9ffb18f93462e5f749d3444ce081290352c6070d014c93feb2
+  version: 11.0.0
+  url: https://files.pythonhosted.org/packages/41/c3/94f33af0762ed76b5a237c5797e088aa57f2b7fa8ee7932d399087be66a8/pillow-11.0.0-cp310-cp310-manylinux_2_28_x86_64.whl
+  sha256: 1a61b54f87ab5786b8479f81c4b11f4d61702830354520837f8cc791ebba0f5f
   requires_dist:
   - furo ; extra == 'docs'
   - olefile ; extra == 'docs'
-  - sphinx>=2.4 ; extra == 'docs'
+  - sphinx>=8.1 ; extra == 'docs'
   - sphinx-copybutton ; extra == 'docs'
   - sphinx-inline-tabs ; extra == 'docs'
-  - sphinx-removed-in ; extra == 'docs'
   - sphinxext-opengraph ; extra == 'docs'
   - olefile ; extra == 'fpx'
   - olefile ; extra == 'mic'
@@ -1184,7 +1367,7 @@ packages:
   - pytest-timeout ; extra == 'tests'
   - typing-extensions ; python_full_version < '3.10' and extra == 'typing'
   - defusedxml ; extra == 'xmp'
-  requires_python: '>=3.8'
+  requires_python: '>=3.9'
 - kind: conda
   name: pip
   version: '24.2'
@@ -1267,9 +1450,9 @@ packages:
   sha256: 2f846a466dd023513240bc140ad2dd73bfc080a5d85a710afdb728c420a5a2b9
   requires_dist:
   - platformdirs>=2.2.0
-  - astroid<=3.4.0.dev0,>=3.3.4
-  - isort!=5.13.0,<6,>=4.2.5
-  - mccabe<0.8,>=0.6
+  - astroid>=3.3.4,<=3.4.0.dev0
+  - isort>=4.2.5,!=5.13.0,<6
+  - mccabe>=0.6,<0.8
   - tomlkit>=0.10.1
   - typing-extensions>=3.10.0 ; python_full_version < '3.10'
   - dill>=0.2 ; python_full_version < '3.11'
@@ -1302,7 +1485,7 @@ packages:
   requires_dist:
   - iniconfig
   - packaging
-  - pluggy<2,>=1.5
+  - pluggy>=1.5,<2
   - exceptiongroup>=1.0.0rc8 ; python_full_version < '3.11'
   - tomli>=1 ; python_full_version < '3.11'
   - colorama ; sys_platform == 'win32'
@@ -1368,7 +1551,7 @@ packages:
   sha256: a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427
   requires_dist:
   - six>=1.5
-  requires_python: '!=3.0.*,!=3.1.*,!=3.2.*,>=2.7'
+  requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*'
 - kind: pypi
   name: pyyaml
   version: 6.0.2
@@ -1412,8 +1595,8 @@ packages:
   url: https://files.pythonhosted.org/packages/e5/c0/b0fba8259b61c938c9733da9346b9f93e00881a9db22aafdd72f6ae0ec05/s3transfer-0.10.3-py3-none-any.whl
   sha256: 263ed587a5803c6c708d3ce44dc4dfedaab4c1a32e8329bab818933d79ddcf5d
   requires_dist:
-  - botocore<2.0a0,>=1.33.2
-  - botocore[crt]<2.0a0,>=1.33.2 ; extra == 'crt'
+  - botocore>=1.33.2,<2.0a0
+  - botocore[crt]>=1.33.2,<2.0a0 ; extra == 'crt'
   requires_python: '>=3.8'
 - kind: pypi
   name: scipy
@@ -1421,7 +1604,7 @@ packages:
   url: https://files.pythonhosted.org/packages/47/78/b0c2c23880dd1e99e938ad49ccfb011ae353758a2dc5ed7ee59baff684c3/scipy-1.14.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: 8e32dced201274bf96899e6491d9ba3e9a5f6b336708656466ad0522d8528f69
   requires_dist:
-  - numpy<2.3,>=1.23.5
+  - numpy>=1.23.5,<2.3
   - pytest ; extra == 'test'
   - pytest-cov ; extra == 'test'
   - pytest-timeout ; extra == 'test'
@@ -1437,7 +1620,7 @@ packages:
   - cython ; extra == 'test'
   - meson ; extra == 'test'
   - ninja ; sys_platform != 'emscripten' and extra == 'test'
-  - sphinx<=7.3.7,>=5.0.0 ; extra == 'doc'
+  - sphinx>=5.0.0,<=7.3.7 ; extra == 'doc'
   - pydata-sphinx-theme>=0.15.2 ; extra == 'doc'
   - sphinx-design>=0.4.0 ; extra == 'doc'
   - matplotlib>=3.5 ; extra == 'doc'
@@ -1488,10 +1671,10 @@ packages:
 - kind: pypi
   name: sympy
   version: 1.13.1
-  url: https://download.pytorch.org/whl/sympy-1.13.1-py3-none-any.whl#sha256=db36cdc64bf61b9b24578b6f7bab1ecdd2452cf008f34faa33776680c26d66f8
+  url: https://files.pythonhosted.org/packages/b2/fe/81695a1aa331a842b582453b605175f419fe8540355886031328089d840a/sympy-1.13.1-py3-none-any.whl
   sha256: db36cdc64bf61b9b24578b6f7bab1ecdd2452cf008f34faa33776680c26d66f8
   requires_dist:
-  - mpmath<1.4,>=1.1.0
+  - mpmath>=1.1.0,<1.4
   - pytest>=7.1.0 ; extra == 'dev'
   - hypothesis>=6.70.0 ; extra == 'dev'
   requires_python: '>=3.8'
@@ -1514,9 +1697,9 @@ packages:
   timestamp: 1699202167581
 - kind: pypi
   name: tomli
-  version: 2.0.2
-  url: https://files.pythonhosted.org/packages/cf/db/ce8eda256fa131af12e0a76d481711abe4681b6923c27efb9a255c9e4594/tomli-2.0.2-py3-none-any.whl
-  sha256: 2ebe24485c53d303f690b0ec092806a085f07af5a5aa1464f3931eec36caaa38
+  version: 2.1.0
+  url: https://files.pythonhosted.org/packages/de/f7/4da0ffe1892122c9ea096c57f64c2753ae5dd3ce85488802d11b0992cc6d/tomli-2.1.0-py3-none-any.whl
+  sha256: a5c57c3d1c56f5ccdf89f6523458f60ef716e210fc47c4cfb188c5ba473e0391
   requires_python: '>=3.8'
 - kind: pypi
   name: tomlkit
@@ -1526,26 +1709,27 @@ packages:
   requires_python: '>=3.8'
 - kind: pypi
   name: torch
-  version: 2.5.1+cu121
-  url: https://download.pytorch.org/whl/cu121/torch-2.5.1%2Bcu121-cp310-cp310-linux_x86_64.whl#sha256=92af92c569de5da937dd1afb45ecfdd598ec1254cf2e49e3d698cb24d71aae14
-  sha256: 92af92c569de5da937dd1afb45ecfdd598ec1254cf2e49e3d698cb24d71aae14
+  version: 2.5.1
+  url: https://files.pythonhosted.org/packages/2a/ef/834af4a885b31a0b32fff2d80e1e40f771e1566ea8ded55347502440786a/torch-2.5.1-cp310-cp310-manylinux1_x86_64.whl
+  sha256: 71328e1bbe39d213b8721678f9dcac30dfc452a46d586f1d514a6aa0a99d4744
   requires_dist:
   - filelock
   - typing-extensions>=4.8.0
   - networkx
   - jinja2
   - fsspec
-  - nvidia-cuda-nvrtc-cu12==12.1.105 ; platform_machine == 'x86_64' and platform_system == 'Linux'
-  - nvidia-cuda-runtime-cu12==12.1.105 ; platform_machine == 'x86_64' and platform_system == 'Linux'
-  - nvidia-cuda-cupti-cu12==12.1.105 ; platform_machine == 'x86_64' and platform_system == 'Linux'
+  - nvidia-cuda-nvrtc-cu12==12.4.127 ; platform_machine == 'x86_64' and platform_system == 'Linux'
+  - nvidia-cuda-runtime-cu12==12.4.127 ; platform_machine == 'x86_64' and platform_system == 'Linux'
+  - nvidia-cuda-cupti-cu12==12.4.127 ; platform_machine == 'x86_64' and platform_system == 'Linux'
   - nvidia-cudnn-cu12==9.1.0.70 ; platform_machine == 'x86_64' and platform_system == 'Linux'
-  - nvidia-cublas-cu12==12.1.3.1 ; platform_machine == 'x86_64' and platform_system == 'Linux'
-  - nvidia-cufft-cu12==11.0.2.54 ; platform_machine == 'x86_64' and platform_system == 'Linux'
-  - nvidia-curand-cu12==10.3.2.106 ; platform_machine == 'x86_64' and platform_system == 'Linux'
-  - nvidia-cusolver-cu12==11.4.5.107 ; platform_machine == 'x86_64' and platform_system == 'Linux'
-  - nvidia-cusparse-cu12==12.1.0.106 ; platform_machine == 'x86_64' and platform_system == 'Linux'
+  - nvidia-cublas-cu12==12.4.5.8 ; platform_machine == 'x86_64' and platform_system == 'Linux'
+  - nvidia-cufft-cu12==11.2.1.3 ; platform_machine == 'x86_64' and platform_system == 'Linux'
+  - nvidia-curand-cu12==10.3.5.147 ; platform_machine == 'x86_64' and platform_system == 'Linux'
+  - nvidia-cusolver-cu12==11.6.1.9 ; platform_machine == 'x86_64' and platform_system == 'Linux'
+  - nvidia-cusparse-cu12==12.3.1.170 ; platform_machine == 'x86_64' and platform_system == 'Linux'
   - nvidia-nccl-cu12==2.21.5 ; platform_machine == 'x86_64' and platform_system == 'Linux'
-  - nvidia-nvtx-cu12==12.1.105 ; platform_machine == 'x86_64' and platform_system == 'Linux'
+  - nvidia-nvtx-cu12==12.4.127 ; platform_machine == 'x86_64' and platform_system == 'Linux'
+  - nvidia-nvjitlink-cu12==12.4.127 ; platform_machine == 'x86_64' and platform_system == 'Linux'
   - triton==3.1.0 ; python_full_version < '3.13' and platform_machine == 'x86_64' and platform_system == 'Linux'
   - sympy==1.12.1 ; python_full_version == '3.8.*'
   - setuptools ; python_full_version >= '3.12'
@@ -1556,7 +1740,7 @@ packages:
 - kind: pypi
   name: triton
   version: 3.1.0
-  url: https://download.pytorch.org/whl/triton-3.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl#sha256=6b0dd10a925263abbe9fa37dcde67a5e9b2383fc269fdf59f5657cac38c5d1d8
+  url: https://files.pythonhosted.org/packages/98/29/69aa56dc0b2eb2602b553881e34243475ea2afd9699be042316842788ff5/triton-3.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: 6b0dd10a925263abbe9fa37dcde67a5e9b2383fc269fdf59f5657cac38c5d1d8
   requires_dist:
   - filelock
@@ -1574,9 +1758,9 @@ packages:
   - tabulate ; extra == 'tutorials'
 - kind: pypi
   name: typing-extensions
-  version: 4.9.0
-  url: https://download.pytorch.org/whl/typing_extensions-4.9.0-py3-none-any.whl#sha256=af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd
-  sha256: af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd
+  version: 4.12.2
+  url: https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl
+  sha256: 04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d
   requires_python: '>=3.8'
 - kind: conda
   name: tzdata
@@ -1593,21 +1777,16 @@ packages:
   timestamp: 1728047496079
 - kind: pypi
   name: urllib3
-  version: 1.26.13
-  url: https://download.pytorch.org/whl/urllib3-1.26.13-py2.py3-none-any.whl#sha256=47cc05d99aaa09c9e72ed5809b60e7ba354e64b59c9c173ac3018642d8bb41fc
-  sha256: 47cc05d99aaa09c9e72ed5809b60e7ba354e64b59c9c173ac3018642d8bb41fc
+  version: 2.2.3
+  url: https://files.pythonhosted.org/packages/ce/d9/5f4c13cecde62396b0d3fe530a50ccea91e7dfc1ccf0e09c228841bb5ba8/urllib3-2.2.3-py3-none-any.whl
+  sha256: ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac
   requires_dist:
-  - brotlicffi>=0.8.0 ; (os_name != 'nt' and platform_python_implementation != 'CPython' and extra == 'brotli') or (python_full_version >= '3' and platform_python_implementation != 'CPython' and extra == 'brotli')
-  - brotli>=1.0.9 ; (os_name != 'nt' and platform_python_implementation == 'CPython' and extra == 'brotli') or (python_full_version >= '3' and platform_python_implementation == 'CPython' and extra == 'brotli')
-  - brotlipy>=0.6.0 ; python_full_version < '3' and os_name == 'nt' and extra == 'brotli'
-  - pyopenssl>=0.14 ; extra == 'secure'
-  - cryptography>=1.3.4 ; extra == 'secure'
-  - idna>=2.0.0 ; extra == 'secure'
-  - certifi ; extra == 'secure'
-  - urllib3-secure-extra ; extra == 'secure'
-  - ipaddress ; python_full_version == '2.7.*' and extra == 'secure'
-  - pysocks!=1.5.7,<2.0,>=1.5.6 ; extra == 'socks'
-  requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*'
+  - brotli>=1.0.9 ; platform_python_implementation == 'CPython' and extra == 'brotli'
+  - brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'brotli'
+  - h2>=4,<5 ; extra == 'h2'
+  - pysocks>=1.5.6,!=1.5.7,<2.0 ; extra == 'socks'
+  - zstandard>=0.18.0 ; extra == 'zstd'
+  requires_python: '>=3.8'
 - kind: conda
   name: wheel
   version: 0.45.0
@@ -1620,6 +1799,7 @@ packages:
   depends:
   - python >=3.8
   license: MIT
+  license_family: MIT
   purls:
   - pkg:pypi/wheel?source=hash-mapping
   size: 62755

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ isaacsim-rl="==4.2.0.2"
 isaacsim-replicator="==4.2.0.2"
 isaacsim-extscache-physics="==4.2.0.2"
 isaacsim-extscache-kit-sdk="==4.2.0.2"
-# isaacsim-extscache-kit="==4.2.0.2"
+isaacsim-extscache-kit="==4.2.0.2"
 isaacsim-app="==4.2.0.2"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,13 @@ description = "A python package template"
 readme = "README.md"
 license = "MIT"
 
-dependencies = []
+requires-python = ">=3.10,<3.11"
+
+dependencies = ["isaacsim==4.2.0.2",
+              "isaacsim-extscache-kit",
+              "isaacsim-extscache-kit-sdk",
+              "isaacsim-extscache-physics"
+              ]
 
 [project.urls]
 Source = "https://github.com/blooop/isaac_lab_env"
@@ -23,18 +29,9 @@ libc = { family="glibc", version="2.35" }
 python = "3.10.*"
 pip = "==24.2"
 
-[tool.pixi.pypi-options]
-extra-index-urls = ["https://download.pytorch.org/whl/cu121","https://pypi.nvidia.com"]
 
 [tool.pixi.pypi-dependencies]
 isaac_lab_env = { path = ".", editable = true }
-torch = ">=2.1.0,<3.0.0"
-isaacsim-rl="==4.2.0.2"
-isaacsim-replicator="==4.2.0.2"
-isaacsim-extscache-physics="==4.2.0.2"
-isaacsim-extscache-kit-sdk="==4.2.0.2"
-isaacsim-extscache-kit="==4.2.0.2"
-isaacsim-app="==4.2.0.2"
 
 
 [project.optional-dependencies]
@@ -61,7 +58,7 @@ default = {features = ["test"], solve-group = "default" }
 
 [tool.pixi.tasks]
 #Project Tasks
-isaacsim = "isaacsim"
+isaacsim = "isaacsim omni.isaac.sim.python.kit"
 
 #CI Tasks
 format = "black ."


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Add isaacsim-extscache-kit to the list of dependencies in pyproject.toml.