### PR TITLE
Feature/rockerc

### DIFF
--- a/rockerc.yaml
+++ b/rockerc.yaml
@@ -13,5 +13,5 @@ args:
   - pull 
   - deps
   - git 
-  - lazygit
+  - isaacsim
   - pixi

--- a/scripts/isolated_isaac.py
+++ b/scripts/isolated_isaac.py
@@ -13,3 +13,7 @@ import subprocess
 
 os.environ["OMNI_KIT_ACCEPT_EULA"] = "yes"
 subprocess.run(["isaacsim", "omni.isaac.sim.kit"], check=True)
+
+# # raw commands
+# isaacsim omni.isaac.sim.kit
+# isaacsim omni.isaac.sim.python.kit


### PR DESCRIPTION
## Summary by Sourcery

Set up Rocker to run Isaac Sim.

Build:
- Add `isaacsim` to Rocker.

Chores:
- Remove `lazygit` from Rocker.